### PR TITLE
Fix prewarming caused by undefined cfn

### DIFF
--- a/lib/jets/commands/call.rb
+++ b/lib/jets/commands/call.rb
@@ -17,7 +17,9 @@ class Jets::Commands::Call
   end
 
   def function_name
-    if @guess
+    if @provided_function_name.starts_with?(Jets.config.project_namespace)
+      @provided_function_name # fully qualified function name
+    elsif @guess      
       ensure_guesses_found! # possibly exits here
       guesser.function_name # guesser adds namespace already
     else

--- a/lib/jets/preheat.rb
+++ b/lib/jets/preheat.rb
@@ -1,6 +1,7 @@
 module Jets
   class Preheat
     extend Memoist
+    include Jets::AwsServices
 
     # Examples:
     #

--- a/lib/jets/preheat.rb
+++ b/lib/jets/preheat.rb
@@ -24,6 +24,7 @@ module Jets
 
     # Makes remote call to the Lambda function.
     def warm(function_name)
+      puts "Calling warm for function: '#{function_name.inspect}'"
       Jets::Commands::Call.new(function_name, '{"_prewarm": "1"}', @options).run unless Jets.env.test?
     end
 


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.

- [N/A] I've added tests (if it's a bug, feature or enhancement)
- [N/A] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix prewarming

## Context

https://github.com/boltops-tools/jets/issues/659

## How to Test

Deploys any Jets app with prewarming enabled and notice that the prewarming lambda function succeeds

## Version Changes

4.0.2
